### PR TITLE
Fix ᵖ function

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -4,7 +4,7 @@ var Ξ=[],//stack
 		ℹ=i=>[i=i!=[]._?document.getElementById("c").value[i]:document.getElementById("c").value,Ξ.push(i)][0],//source
 
 		//stack functions
-		ᵖ=(i=0)=>{Array.prototype.slice.call(arguments).map(x=>Ξ.push(x))},
+		ᵖ=(i=0,...r)=>{Ξ.push(i,...r)},
 		ᵍ=i=>i!=[]._?Ξ[i<0?Ξ.length+i:i]:Ξ[Ξ.length-1],
 		ʳ=(i=Ξ.length-1)=>Ξ.splice(i,1),
 		ᶜ=i=>Ξ=[],


### PR DESCRIPTION
Use rest arguments instead of the `arguments` object, which is [not defined for arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Lexical_arguments).

Without this fix, i get a `ReferenceError: arguments is not defined` exception for the example loop on the homepage (using Firefox 43). Maybe some earlier versions of Firefox did expose `arguments` on arrow functions, i don't know.

Anyway, nice project! Hope to see more entries on codegolf.stackexchange.com :smiley_cat: 
